### PR TITLE
[Coverage] BuildBot.Watchtower — increase code coverage to 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 - BuildBot.GitHub - Increased code coverage to 100%
 - [BuildBot.CloudFormation] Increase code coverage to 100%
+- Tests for BuildBot.Watchtower to increase code coverage to 100%
 ### Fixed
 - Suppress known Scriban 6.2.0 vulnerabilities pending upgrade
 ### Changed

--- a/src/BuildBot.Watchtower.Tests/BuildBot.Watchtower.Tests.csproj
+++ b/src/BuildBot.Watchtower.Tests/BuildBot.Watchtower.Tests.csproj
@@ -1,0 +1,72 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <DebuggerSupport>true</DebuggerSupport>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>true</EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
+    <Features>strict;flow-analysis</Features>
+    <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
+    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <IsTrimmable>false</IsTrimmable>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <LangVersion>latest</LangVersion>
+    <NoWarn />
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <Nullable>enable</Nullable>
+    <OptimizationPreference>speed</OptimizationPreference>
+    <OutputType>Exe</OutputType>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <TargetFramework>net10.0</TargetFramework>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TieredCompilation>true</TieredCompilation>
+    <TieredPGO>true</TieredPGO>
+    <TreatSpecificWarningsAsErrors />
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')" />
+  <ItemGroup>
+    <ProjectReference Include="..\BuildBot.Watchtower\BuildBot.Watchtower.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.25.2243" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="codecracker.CSharp" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Credfeto.Enumeration.Source.Generation" Version="1.2.139.1741" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.35.1745" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.25.2243" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.22" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="1.6.4" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers" Version="1.9.1" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SmartAnalyzers.CSharpExtensions.Annotations" Version="4.2.11" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.20.0.135146" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="ToStringWithoutOverrideAnalyzer" Version="0.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="xunit.analyzers" Version="1.27.0" PrivateAssets="All" ExcludeAssets="runtime" />
+  </ItemGroup>
+</Project>

--- a/src/BuildBot.Watchtower.Tests/DependencyInjectionTests.cs
+++ b/src/BuildBot.Watchtower.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,24 @@
+using BuildBot.Watchtower.Publishers;
+using FunFair.Test.Common;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BuildBot.Watchtower.Tests;
+
+public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
+{
+    public DependencyInjectionTests(ITestOutputHelper output)
+        : base(output: output, dependencyInjectionRegistration: Configure) { }
+
+    private static IServiceCollection Configure(IServiceCollection services)
+    {
+        return services.AddMockedService<IMediator>().AddWatchtower();
+    }
+
+    [Fact]
+    public void WatchTowerPublishMessageNotificationHandlerMustBeRegistered()
+    {
+        this.RequireService<WatchTowerPublishMessageNotificationHandler>();
+    }
+}

--- a/src/BuildBot.Watchtower.Tests/Models/WatchTowerPublishMessageTests.cs
+++ b/src/BuildBot.Watchtower.Tests/Models/WatchTowerPublishMessageTests.cs
@@ -1,0 +1,39 @@
+using BuildBot.ServiceModel.Watchtower;
+using BuildBot.Watchtower.Models;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace BuildBot.Watchtower.Tests.Models;
+
+public sealed class WatchTowerPublishMessageTests : TestBase
+{
+    [Fact]
+    public void ModelPropertyMatchesConstructorArgument()
+    {
+        WatchTowerMessage model = new(Message: "Service deployed", Title: "Deployment");
+
+        WatchTowerPublishMessage notification = new(model);
+
+        Assert.Equal(expected: model, actual: notification.Model);
+    }
+
+    [Fact]
+    public void TwoNotificationsWithSameModelAreEqual()
+    {
+        WatchTowerMessage model = new(Message: "Service deployed", Title: "Deployment");
+
+        WatchTowerPublishMessage first = new(model);
+        WatchTowerPublishMessage second = new(model);
+
+        Assert.Equal(expected: first, actual: second);
+    }
+
+    [Fact]
+    public void TwoNotificationsWithDifferentModelsAreNotEqual()
+    {
+        WatchTowerPublishMessage first = new(new WatchTowerMessage(Message: "Service deployed", Title: "Deployment"));
+        WatchTowerPublishMessage second = new(new WatchTowerMessage(Message: "Service failed", Title: "Failure"));
+
+        Assert.NotEqual(expected: first, actual: second);
+    }
+}

--- a/src/BuildBot.Watchtower.Tests/Publishers/WatchTowerPublishMessageNotificationHandlerTests.cs
+++ b/src/BuildBot.Watchtower.Tests/Publishers/WatchTowerPublishMessageNotificationHandlerTests.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BuildBot.Discord.Models;
+using BuildBot.ServiceModel.Watchtower;
+using BuildBot.Watchtower.Models;
+using BuildBot.Watchtower.Publishers;
+using FunFair.Test.Common;
+using Mediator;
+using NSubstitute;
+using Xunit;
+
+namespace BuildBot.Watchtower.Tests.Publishers;
+
+public sealed class WatchTowerPublishMessageNotificationHandlerTests : TestBase
+{
+    [Fact]
+    public async Task HandlePublishesBotMessageViaMediatorAsync()
+    {
+        IMediator mediator = GetSubstitute<IMediator>();
+        WatchTowerPublishMessageNotificationHandler handler = new(mediator);
+
+        WatchTowerMessage model = new(Message: "Service deployed", Title: "Deployment");
+        WatchTowerPublishMessage notification = new(model);
+
+        await handler.Handle(notification: notification, cancellationToken: this.CancellationToken());
+
+        await mediator.Received(1).Publish(Arg.Any<BotMessage>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/src/BuildBot.Watchtower/WatchtowerSetup.cs
+++ b/src/BuildBot.Watchtower/WatchtowerSetup.cs
@@ -1,3 +1,4 @@
+using BuildBot.Watchtower.Publishers;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BuildBot.Watchtower;
@@ -6,6 +7,6 @@ public static class WatchtowerSetup
 {
     public static IServiceCollection AddWatchtower(this IServiceCollection services)
     {
-        return services;
+        return services.AddSingleton<WatchTowerPublishMessageNotificationHandler>();
     }
 }

--- a/src/BuildBot.slnx
+++ b/src/BuildBot.slnx
@@ -20,6 +20,7 @@
   <Project Path="BuildBot.Json/BuildBot.Json.csproj" />
   <Project Path="BuildBot.ServiceModel/BuildBot.ServiceModel.csproj" />
   <Project Path="BuildBot.Tests/BuildBot.Tests.csproj" />
+  <Project Path="BuildBot.Watchtower.Tests/BuildBot.Watchtower.Tests.csproj" />
   <Project Path="BuildBot.Watchtower/BuildBot.Watchtower.csproj" />
   <Project Path="BuildBot/BuildBot.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

- Creates `BuildBot.Watchtower.Tests` project with 5 tests covering all source types in `BuildBot.Watchtower`
- Registers `WatchTowerPublishMessageNotificationHandler` explicitly in `WatchtowerSetup.AddWatchtower()` (was missing)
- Tests cover `WatchTowerPublishMessage` (record equality and construction), `WatchTowerPublishMessageNotificationHandler` (publishes `BotMessage` via mediator), and `WatchtowerSetup` (DI registration)

Closes #361

## Test plan

- [ ] `BuildBot.Watchtower.Tests` builds with zero warnings
- [ ] All 5 tests pass
- [ ] `dotnet buildcheck` reports no errors
- [ ] CI passes