### PR TITLE
test(BuildBot.Health): increase code coverage to 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - BuildBot.GitHub - Increased code coverage to 100%
 - [BuildBot.CloudFormation] Increase code coverage to 100%
 - Tests for BuildBot.Watchtower to increase code coverage to 100%
+- BuildBot.Health.Tests: new test project covering BuildBot.Health at 100% line and branch coverage
 ### Fixed
 - Suppress known Scriban 6.2.0 vulnerabilities pending upgrade
 ### Changed

--- a/src/BuildBot.Health.Tests/BuildBot.Health.Tests.csproj
+++ b/src/BuildBot.Health.Tests/BuildBot.Health.Tests.csproj
@@ -1,0 +1,72 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <DebuggerSupport>true</DebuggerSupport>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>true</EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
+    <Features>strict;flow-analysis</Features>
+    <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
+    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <IsTrimmable>false</IsTrimmable>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <LangVersion>latest</LangVersion>
+    <NoWarn />
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <Nullable>enable</Nullable>
+    <OptimizationPreference>speed</OptimizationPreference>
+    <OutputType>Exe</OutputType>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <TargetFramework>net10.0</TargetFramework>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TieredCompilation>true</TieredCompilation>
+    <TieredPGO>true</TieredPGO>
+    <TreatSpecificWarningsAsErrors />
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')" />
+  <ItemGroup>
+    <ProjectReference Include="..\BuildBot.Health\BuildBot.Health.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.25.2243" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="codecracker.CSharp" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Credfeto.Enumeration.Source.Generation" Version="1.2.139.1741" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.35.1745" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.25.2243" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.22" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="1.6.4" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers" Version="1.9.1" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SmartAnalyzers.CSharpExtensions.Annotations" Version="4.2.11" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.20.0.135146" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="ToStringWithoutOverrideAnalyzer" Version="0.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="xunit.analyzers" Version="1.27.0" PrivateAssets="All" ExcludeAssets="runtime" />
+  </ItemGroup>
+</Project>

--- a/src/BuildBot.Health.Tests/DependencyInjectionTests.cs
+++ b/src/BuildBot.Health.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,23 @@
+using BuildBot.Health;
+using FunFair.Test.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BuildBot.Health.Tests;
+
+public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
+{
+    public DependencyInjectionTests(ITestOutputHelper output)
+        : base(output: output, dependencyInjectionRegistration: Configure) { }
+
+    private static IServiceCollection Configure(IServiceCollection services)
+    {
+        return services.AddStatus();
+    }
+
+    [Fact]
+    public void ServerStatusMustBeRegistered()
+    {
+        this.RequireService<IServerStatus>();
+    }
+}

--- a/src/BuildBot.Health.Tests/Publishers/CheckStatusPublisherTests.cs
+++ b/src/BuildBot.Health.Tests/Publishers/CheckStatusPublisherTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using BuildBot.Health;
+using BuildBot.Health.Publishers;
+using BuildBot.ServiceModel.ComponentStatus;
+using FunFair.Test.Common;
+using NSubstitute;
+using Xunit;
+
+namespace BuildBot.Health.Tests.Publishers;
+
+public sealed class CheckStatusPublisherTests : TestBase
+{
+    [Fact]
+    public async Task Handle_ReturnsStatusFromServerStatusAsync()
+    {
+        IServerStatus serverStatus = GetSubstitute<IServerStatus>();
+        IReadOnlyList<ServiceStatus> expected = [new ServiceStatus(Name: "db", Ok: true)];
+        serverStatus.CurrentStatus().Returns(expected);
+
+        CheckStatusPublisher publisher = new(serverStatus);
+        CheckStatus command = new(Source: "test");
+
+        IReadOnlyList<ServiceStatus> result = await publisher.Handle(
+            command: command,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.Same(expected: expected, actual: result);
+    }
+
+    [Fact]
+    public async Task Handle_WithNullSource_ReturnsStatusFromServerStatusAsync()
+    {
+        IServerStatus serverStatus = GetSubstitute<IServerStatus>();
+        IReadOnlyList<ServiceStatus> expected = [];
+        serverStatus.CurrentStatus().Returns(expected);
+
+        CheckStatusPublisher publisher = new(serverStatus);
+        CheckStatus command = new(Source: null);
+
+        IReadOnlyList<ServiceStatus> result = await publisher.Handle(
+            command: command,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.Same(expected: expected, actual: result);
+    }
+}

--- a/src/BuildBot.Health.Tests/Services/ServerStatusTests.cs
+++ b/src/BuildBot.Health.Tests/Services/ServerStatusTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using BuildBot.Health.Services;
+using BuildBot.ServiceModel.ComponentStatus;
+using FunFair.Test.Common;
+using NSubstitute;
+using Xunit;
+
+namespace BuildBot.Health.Tests.Services;
+
+public sealed class ServerStatusTests : TestBase
+{
+    [Fact]
+    public void CurrentStatus_WithNoComponents_ReturnsEmptyList()
+    {
+        ServerStatus serverStatus = new(componentStatusChecks: []);
+
+        IReadOnlyList<ServiceStatus> result = serverStatus.CurrentStatus();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void CurrentStatus_WithOneComponent_ReturnsSingleStatus()
+    {
+        IComponentStatus component = GetSubstitute<IComponentStatus>();
+        component.GetStatus().Returns(new ServiceStatus(Name: "db", Ok: true));
+
+        ServerStatus serverStatus = new(componentStatusChecks: [component]);
+
+        IReadOnlyList<ServiceStatus> result = serverStatus.CurrentStatus();
+
+        Assert.Single(result);
+        Assert.Equal(expected: new ServiceStatus(Name: "db", Ok: true), actual: result[0]);
+    }
+
+    [Fact]
+    public void CurrentStatus_WithMultipleComponents_ReturnsSortedByName()
+    {
+        IComponentStatus componentZ = GetSubstitute<IComponentStatus>();
+        componentZ.GetStatus().Returns(new ServiceStatus(Name: "zebra", Ok: true));
+
+        IComponentStatus componentA = GetSubstitute<IComponentStatus>();
+        componentA.GetStatus().Returns(new ServiceStatus(Name: "alpha", Ok: false));
+
+        IComponentStatus componentM = GetSubstitute<IComponentStatus>();
+        componentM.GetStatus().Returns(new ServiceStatus(Name: "mongo", Ok: true));
+
+        ServerStatus serverStatus = new(componentStatusChecks: [componentZ, componentA, componentM]);
+
+        IReadOnlyList<ServiceStatus> result = serverStatus.CurrentStatus();
+
+        Assert.Equal(expected: 3, actual: result.Count);
+        Assert.Equal(expected: "alpha", actual: result[0].Name);
+        Assert.Equal(expected: "mongo", actual: result[1].Name);
+        Assert.Equal(expected: "zebra", actual: result[2].Name);
+    }
+}

--- a/src/BuildBot.slnx
+++ b/src/BuildBot.slnx
@@ -16,6 +16,7 @@
   <Project Path="BuildBot.Discord/BuildBot.Discord.csproj" />
   <Project Path="BuildBot.GitHub.Tests/BuildBot.GitHub.Tests.csproj" />
   <Project Path="BuildBot.GitHub/BuildBot.GitHub.csproj" />
+  <Project Path="BuildBot.Health.Tests/BuildBot.Health.Tests.csproj" />
   <Project Path="BuildBot.Health/BuildBot.Health.csproj" />
   <Project Path="BuildBot.Json/BuildBot.Json.csproj" />
   <Project Path="BuildBot.ServiceModel/BuildBot.ServiceModel.csproj" />


### PR DESCRIPTION
## Summary

- Add `BuildBot.Health.Tests` project covering `BuildBot.Health` at 100% line and branch coverage
- Tests cover `CheckStatusPublisher`, `ServerStatus`, and `StatusSetup` DI registration
- All 6 new tests pass; all 87 tests in the solution pass

Closes #360

## Test plan

- [x] `DependencyInjectionTests` — verifies `IServerStatus` is registered via `AddStatus()`
- [x] `Publishers/CheckStatusPublisherTests` — verifies `Handle` delegates to `IServerStatus.CurrentStatus()` with both non-null and null `Source`
- [x] `Services/ServerStatusTests` — verifies `CurrentStatus()` returns empty list, single item, and multiple items sorted by name