### PR TITLE
fix: guard against IndexOutOfRangeException when Branches list is empty in GithubStatusNotificationHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Added null guards for botMessageChannel and botReleaseMessageChannel parameters in BotService constructor
 - Pass ILogger to HealthCheckClient.ExecuteAsync to match new API in Credfeto.Docker.HealthCheck.Http.Client 0.0.72.928
 - Made DiscordChannelAdapter testable by accepting ITextChannel instead of the sealed SocketTextChannel, and added unit tests
+- Guard against IndexOutOfRangeException when Branches list is empty in GithubStatusNotificationHandler
 ### Changed
 - Dependencies - Updated NSubstitute.Analyzers.CSharp to 1.0.17
 - Switched to use minimal APIs

--- a/src/BuildBot.GitHub.Tests/Publishers/GithubStatusNotificationHandlerTests.cs
+++ b/src/BuildBot.GitHub.Tests/Publishers/GithubStatusNotificationHandlerTests.cs
@@ -20,6 +20,16 @@ public sealed class GithubStatusNotificationHandlerTests : TestBase
 
     private static Status MakeStatus(string state)
     {
+        return MakeStatusWithBranches(state: state, branches: [new Branch(name: "main")]);
+    }
+
+    private static Status MakeStatusWithNoBranches(string state)
+    {
+        return MakeStatusWithBranches(state: state, branches: []);
+    }
+
+    private static Status MakeStatusWithBranches(string state, Branch[] branches)
+    {
         Repository repository = new(
             id: 1,
             name: "BuildBot",
@@ -49,7 +59,7 @@ public sealed class GithubStatusNotificationHandlerTests : TestBase
             repository: repository,
             context: "ci/build",
             state: state,
-            branches: [new Branch(name: "main")],
+            branches: branches,
             description: "Build finished",
             statusCommit: statusCommit
         );
@@ -86,6 +96,22 @@ public sealed class GithubStatusNotificationHandlerTests : TestBase
         (IMediator mediator, GithubStatusNotificationHandler handler) = this.CreateHandler();
 
         Status status = MakeStatus(state: state);
+        GithubStatus notification = new(status);
+
+        await handler.Handle(notification: notification, cancellationToken: this.CancellationToken());
+
+        await mediator.Received(1).Publish(Arg.Any<INotification>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("success")]
+    [InlineData("failure")]
+    [InlineData("error")]
+    public async Task NonPendingStateWithNoBranchesShouldPublishAsync(string state)
+    {
+        (IMediator mediator, GithubStatusNotificationHandler handler) = this.CreateHandler();
+
+        Status status = MakeStatusWithNoBranches(state: state);
         GithubStatus notification = new(status);
 
         await handler.Handle(notification: notification, cancellationToken: this.CancellationToken());

--- a/src/BuildBot.GitHub/Publishers/GithubStatusNotificationHandler.cs
+++ b/src/BuildBot.GitHub/Publishers/GithubStatusNotificationHandler.cs
@@ -57,7 +57,7 @@ public sealed class GithubStatusNotificationHandler : INotificationHandler<Githu
 
         return new EmbedBuilder()
             .WithTitle(
-                $"{message.Description} for {message.Context} from {message.Repository.Name} ({lastBranch?.Name ?? string.Empty})"
+                $"{message.Description} for {message.Context} from {message.Repository.Name} ({lastBranch?.Name ?? "(unknown)"})"
             )
             .WithUrl(message.TargetUrl)
             .WithDescription($"Built at {message.StatusCommit.Sha}")

--- a/src/BuildBot.GitHub/Publishers/GithubStatusNotificationHandler.cs
+++ b/src/BuildBot.GitHub/Publishers/GithubStatusNotificationHandler.cs
@@ -53,11 +53,11 @@ public sealed class GithubStatusNotificationHandler : INotificationHandler<Githu
 
     private static EmbedBuilder BuildStatusMessage(in Status message)
     {
-        Branch lastBranch = message.Branches[^1];
+        Branch? lastBranch = message.Branches.Count > 0 ? message.Branches[^1] : null;
 
         return new EmbedBuilder()
             .WithTitle(
-                $"{message.Description} for {message.Context} from {message.Repository.Name} ({lastBranch.Name})"
+                $"{message.Description} for {message.Context} from {message.Repository.Name} ({lastBranch?.Name ?? string.Empty})"
             )
             .WithUrl(message.TargetUrl)
             .WithDescription($"Built at {message.StatusCommit.Sha}")
@@ -74,7 +74,7 @@ public sealed class GithubStatusNotificationHandler : INotificationHandler<Githu
     {
         return new EmbedFieldBuilder()
             .WithName("Branch")
-            .WithValue(message.Branches.Select(static b => b.Name).FirstOrDefault());
+            .WithValue(message.Branches.Select(static b => b.Name).FirstOrDefault() ?? "(unknown)");
     }
 
     private static EmbedFieldBuilder AddHeadCommitEmbed(in StatusCommit statusCommit)


### PR DESCRIPTION
## Summary

- Replaced the unchecked `message.Branches[^1]` access in `BuildStatusMessage` with a null-guarded form (`message.Branches.Count > 0 ? message.Branches[^1] : null`), preventing `IndexOutOfRangeException` when the GitHub status payload arrives with an empty `Branches` list.
- Updated the embed title interpolation to use `lastBranch?.Name ?? string.Empty` so an empty branches list produces a valid (if branch-less) title.
- Fixed `AddBranchEmbed` to use `?? "(unknown)"` on the `FirstOrDefault()` result so `WithValue` never receives null or empty (Discord rejects both).
- Added parameterised test cases (`NonPendingStateWithNoBranchesShouldPublishAsync`) covering `success`, `failure`, and `error` states with an empty branches list.

## Test plan

- [ ] All existing tests continue to pass (non-empty branches path unchanged).
- [ ] New `NonPendingStateWithNoBranchesShouldPublishAsync` tests pass for `success`, `failure`, and `error` states.
- [ ] CI build passes.

Closes #365